### PR TITLE
Permission change for Press Clippings

### DIFF
--- a/project/config/pressclippingsnics/config/user.role.supervisor_user.yml
+++ b/project/config/pressclippingsnics/config/user.role.supervisor_user.yml
@@ -274,6 +274,7 @@ permissions:
   - 'use nics_editorial_workflow transition create_new_draft'
   - 'use nics_editorial_workflow transition draft_of_published'
   - 'use nics_editorial_workflow transition publish'
+  - 'use nics_editorial_workflow transition quick_publish'
   - 'use nics_editorial_workflow transition reject'
   - 'use nics_editorial_workflow transition restore'
   - 'use nics_editorial_workflow transition restore_to_draft'


### PR DESCRIPTION
- Allowing supervisors the ability to quick publish content (as discussed in training)