### PR TITLE
D8UN-2670

### DIFF
--- a/project/sites/liofa/modules/custom/liofa_pledges/liofa_pledges.module
+++ b/project/sites/liofa/modules/custom/liofa_pledges/liofa_pledges.module
@@ -39,6 +39,15 @@ function liofa_pledges_webform_submission_insert(WebformSubmissionInterface $web
 function liofa_pledges_node_presave(EntityInterface $entity) {
   // Update the Bulk pledges added through the content type. Only if published.
   if ($entity->bundle() === 'bulk_pledges' && $entity->isPublished()) {
+    $config = \Drupal::configFactory()
+      ->getEditable('liofa_pledges.countsettings');
+    $bulk_pledges_count = $entity->get('field_bulk_number')->value;
+
+    $bulk_pledges = $config->get('bulk_pledge_count') + $bulk_pledges_count;
+
+    $config
+      ->set('bulk_pledge_count', $bulk_pledges)
+      ->save();
     // Update pledge count totals.
     LiofaPledgesController::generateTotals();
 

--- a/project/sites/liofa/modules/custom/liofa_pledges/liofa_pledges.module
+++ b/project/sites/liofa/modules/custom/liofa_pledges/liofa_pledges.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\liofa_pledges\Controller\LiofaPledgesController;
+use Drupal\node\NodeInterface;
 use Drupal\webform\WebformSubmissionInterface;
 
 /**
@@ -41,12 +42,31 @@ function liofa_pledges_node_presave(EntityInterface $entity) {
   if ($entity->bundle() === 'bulk_pledges' && $entity->isPublished()) {
     $config = \Drupal::configFactory()
       ->getEditable('liofa_pledges.countsettings');
-    $bulk_pledges_count = $entity->get('field_bulk_number')->value;
+    $bulk_pledge_count = 0;
+    $bulk_pledges_count_on_node = $entity->get('field_bulk_number')->value;
+    $result = \Drupal::entityTypeManager()
+      ->getStorage('node')
+      ->getAggregateQuery('AND')
+      ->accessCheck(FALSE)
+      ->aggregate('field_bulk_number', 'sum')
+      ->condition('type', 'bulk_pledges')
+      ->condition('status', NodeInterface::PUBLISHED)
+      ->execute();
+    if (!empty($result) && is_array($result)) {
+      $bulk_pledge_count = $result[0]['field_bulk_number_sum'] + $bulk_pledges_count_on_node;
+    }
 
-    $bulk_pledges = $config->get('bulk_pledge_count') + $bulk_pledges_count;
+    // Or this works too.
+//    $bulk_pledges_count = $entity->get('field_bulk_number')->value;
+//
+//    $bulk_pledges = $config->get('bulk_pledge_count') + $bulk_pledges_count;
+//
+//    $config
+//      ->set('bulk_pledge_count', $bulk_pledges)
+//      ->save();
 
     $config
-      ->set('bulk_pledge_count', $bulk_pledges)
+      ->set('bulk_pledge_count', $bulk_pledge_count)
       ->save();
     // Update pledge count totals.
     LiofaPledgesController::generateTotals();

--- a/project/sites/liofa/modules/custom/liofa_pledges/src/Controller/LiofaPledgesController.php
+++ b/project/sites/liofa/modules/custom/liofa_pledges/src/Controller/LiofaPledgesController.php
@@ -70,7 +70,6 @@ class LiofaPledgesController extends ControllerBase {
    */
   public static function generateTotals() {
     $config = \Drupal::configFactory()->getEditable('liofa_pledges.countsettings');
-//    $config->set('bulk_pledge_count', 0)->save();
     // Retrieve pledge count submitted online.
     $onsite_pledges = intval($config->get('pledge_count_submissions'));
     // Now need to get bulk pledges count.

--- a/project/sites/liofa/modules/custom/liofa_pledges/src/Controller/LiofaPledgesController.php
+++ b/project/sites/liofa/modules/custom/liofa_pledges/src/Controller/LiofaPledgesController.php
@@ -70,29 +70,30 @@ class LiofaPledgesController extends ControllerBase {
    */
   public static function generateTotals() {
     $config = \Drupal::configFactory()->getEditable('liofa_pledges.countsettings');
+//    $config->set('bulk_pledge_count', 0)->save();
     // Retrieve pledge count submitted online.
     $onsite_pledges = intval($config->get('pledge_count_submissions'));
     // Now need to get bulk pledges count.
     $bulk_pledge_count = 0;
-    $result = \Drupal::entityTypeManager()->getStorage('node')->getAggregateQuery('AND')
-      ->accessCheck(FALSE)
-      ->aggregate('field_bulk_number', 'sum')
-      ->condition('type', 'bulk_pledges')
-      ->condition('status', NodeInterface::PUBLISHED)
-      ->execute();
-    if (!empty($result) && is_array($result)) {
-      $bulk_pledge_count = $result[0]['field_bulk_number_sum'];
-    }
+//    $result = \Drupal::entityTypeManager()->getStorage('node')->getAggregateQuery('AND')
+//      ->accessCheck(FALSE)
+//      ->aggregate('field_bulk_number', 'sum')
+//      ->condition('type', 'bulk_pledges')
+//      ->condition('status', NodeInterface::PUBLISHED)
+//      ->execute();
+//    if (!empty($result) && is_array($result)) {
+//      $bulk_pledge_count = $result[0]['field_bulk_number_sum'];
+//    }
     // Get pledge count offset.
     $pledge_count_offset = intval($config->get('pledge_count_offset'));
     if (empty($pledge_count_offset)) {
       $pledge_count_offset = 0;
     }
-    // Calculate overall total.
-    $pledge_count_total = $onsite_pledges + $bulk_pledge_count + $pledge_count_offset;
-    $config->set('pledge_count_total', $pledge_count_total)->save();
+    // Calculate overall total. Bulk pledge count is calculated in liofa_pledges.module.
+    $pledge_count_total = $onsite_pledges + $config->get('bulk_pledge_count') + $pledge_count_offset;
     $config->set('onsite_pledges', $onsite_pledges)->save();
-    $config->set('bulk_pledge_count', $bulk_pledge_count)->save();
+//    $config->set('bulk_pledge_count', $bulk_pledge_count)->save();
+    $config->set('pledge_count_total', $pledge_count_total)->save();
   }
 
 }

--- a/project/sites/liofa/modules/custom/liofa_pledges/src/Controller/LiofaPledgesController.php
+++ b/project/sites/liofa/modules/custom/liofa_pledges/src/Controller/LiofaPledgesController.php
@@ -74,7 +74,7 @@ class LiofaPledgesController extends ControllerBase {
     // Retrieve pledge count submitted online.
     $onsite_pledges = intval($config->get('pledge_count_submissions'));
     // Now need to get bulk pledges count.
-    $bulk_pledge_count = 0;
+//    $bulk_pledge_count = 0;
 //    $result = \Drupal::entityTypeManager()->getStorage('node')->getAggregateQuery('AND')
 //      ->accessCheck(FALSE)
 //      ->aggregate('field_bulk_number', 'sum')


### PR DESCRIPTION
The bulk pledge sum wasn't including the current saved bulk pledge node number. So if a user was to add bulk pledges through the content type the number wouldn't update. Or if 2 were added in sequence then only the previous number would be added to the total count.
I am off on Monday but this PR does fix the issue but I'm not sure it is the best way to go?