### PR TITLE
Further work on Truth Recovery site

### DIFF
--- a/project/config/independentpaneltruthrecoveryni/config/block.block.views_block__board_members_board_members_block.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/block.block.views_block__board_members_board_members_block.yml
@@ -1,0 +1,29 @@
+uuid: f4722f55-fac2-4b56-bd4a-36d4fc75df79
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.board_members
+  module:
+    - system
+    - views
+  theme:
+    - independentpaneltruthrecoveryni_theme
+id: views_block__board_members_board_members_block
+theme: independentpaneltruthrecoveryni_theme
+region: content
+weight: 0
+provider: null
+plugin: 'views_block:board_members-board_members_block'
+settings:
+  id: 'views_block:board_members-board_members_block'
+  label: 'Meet the Panel'
+  label_display: '0'
+  provider: views
+  views_label: 'Meet the Panel'
+  items_per_page: none
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: /members-independent-panel

--- a/project/config/independentpaneltruthrecoveryni/config/core.entity_view_display.node.board_member.teaser.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/core.entity_view_display.node.board_member.teaser.yml
@@ -19,24 +19,26 @@ bundle: board_member
 mode: teaser
 content:
   field_member_image:
-    type: entity_reference_label
-    weight: 0
-    region: content
+    type: entity_reference_entity_view
     label: hidden
     settings:
-      link: true
+      view_mode: member_small_image
+      link: false
     third_party_settings: {  }
+    weight: 0
+    region: content
   field_member_role:
     type: string
-    weight: 1
-    region: content
     label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
+    weight: 1
+    region: content
 hidden:
   body: true
   content_moderation_control: true
   field_meta_tags: true
   langcode: true
   links: true
+  search_api_excerpt: true

--- a/project/config/independentpaneltruthrecoveryni/config/core.entity_view_mode.media.member_small_image.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/core.entity_view_mode.media.member_small_image.yml
@@ -1,0 +1,10 @@
+uuid: a8dd5579-130c-43d3-aa0c-c229e4164320
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+id: media.member_small_image
+label: 'Member small image'
+targetEntityType: media
+cache: true

--- a/project/config/independentpaneltruthrecoveryni/config/core.extension.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/core.extension.yml
@@ -61,6 +61,7 @@ module:
   honeypot: 0
   http_cache_control: 0
   image: 0
+  independentpaneltruthrecoveryni_breadcrumbs: 0
   inline_entity_form: 0
   inline_form_errors: 0
   jquery_ui: 0

--- a/project/config/independentpaneltruthrecoveryni/config/entityqueue.entity_queue.board_members_queue.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/entityqueue.entity_queue.board_members_queue.yml
@@ -1,0 +1,26 @@
+uuid: 4cb2c7d9-67cf-457a-bf47-57c62c6c324c
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: board_members_queue
+label: 'Board members queue'
+handler: simple
+handler_configuration: {  }
+entity_settings:
+  target_type: node
+  handler: 'default:node'
+  handler_settings:
+    target_bundles:
+      board_member: board_member
+    sort:
+      field: _none
+      direction: ASC
+    auto_create: false
+    auto_create_bundle: ''
+queue_settings:
+  min_size: 0
+  max_size: 0
+  act_as_queue: false
+  reverse: false

--- a/project/config/independentpaneltruthrecoveryni/config/search_api.index.default_content.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/search_api.index.default_content.yml
@@ -126,6 +126,7 @@ field_settings:
 
 
 
+
       fields:
         - 'entity:node/body'
         - 'entity:node/title'

--- a/project/config/independentpaneltruthrecoveryni/config/search_api.index.default_content.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/search_api.index.default_content.yml
@@ -127,6 +127,7 @@ field_settings:
 
 
 
+
       fields:
         - 'entity:node/body'
         - 'entity:node/title'

--- a/project/config/independentpaneltruthrecoveryni/config/views.view.board_members.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/views.view.board_members.yml
@@ -1,0 +1,195 @@
+uuid: 5d957ac3-39f7-48e0-a19b-d4255f823317
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - entityqueue.entity_queue.board_members_queue
+    - node.type.board_member
+  module:
+    - entityqueue
+    - node
+    - user
+id: board_members
+label: 'Board Members'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Board Members Block'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        entityqueue_relationship:
+          id: entityqueue_relationship
+          table: node_field_data
+          field: entityqueue_relationship
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: entity_queue_position
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+        type:
+          id: type
+          table: node_field_data
+          field: type
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+          value:
+            board_member: board_member
+      style:
+        type: default
+      row:
+        type: 'entity:node'
+        options:
+          view_mode: teaser
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        entityqueue_relationship:
+          id: entityqueue_relationship
+          table: node_field_data
+          field: entityqueue_relationship
+          relationship: none
+          group_type: group
+          admin_label: 'Content queue'
+          entity_type: node
+          plugin_id: entity_queue
+          required: true
+          limit_queue: board_members_queue
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:entityqueue.entity_queue.board_members_queue'
+        - entity_field_info
+        - views_data
+  board_members_block:
+    id: board_members_block
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:entityqueue.entity_queue.board_members_queue'
+        - entity_field_info
+        - views_data

--- a/project/config/independentpaneltruthrecoveryni/config/views.view.publications_search.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/views.view.publications_search.yml
@@ -134,7 +134,20 @@ display:
         type: custom_tag
         options:
           custom_tag: ''
-      empty: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'There were no results found.'
+            format: basic_html
+          tokenize: false
       sorts:
         field_published_date:
           id: field_published_date

--- a/project/config/independentpaneltruthrecoveryni/production/fastly.settings.yml
+++ b/project/config/independentpaneltruthrecoveryni/production/fastly.settings.yml
@@ -1,0 +1,1 @@
+site_id: gyk2sual

--- a/project/sites/independentpaneltruthrecoveryni/modules/independentpaneltruthrecoveryni_breadcrumbs/independentpaneltruthrecoveryni_breadcrumbs.info.yml
+++ b/project/sites/independentpaneltruthrecoveryni/modules/independentpaneltruthrecoveryni_breadcrumbs/independentpaneltruthrecoveryni_breadcrumbs.info.yml
@@ -1,0 +1,5 @@
+name: 'independentpaneltruthrecoveryni breadcrumbs'
+type: module
+description: 'Breadcrumb customisations'
+core_version_requirement: 8.x || ^9 || ^10
+package: 'custom'

--- a/project/sites/independentpaneltruthrecoveryni/modules/independentpaneltruthrecoveryni_breadcrumbs/independentpaneltruthrecoveryni_breadcrumbs.module
+++ b/project/sites/independentpaneltruthrecoveryni/modules/independentpaneltruthrecoveryni_breadcrumbs/independentpaneltruthrecoveryni_breadcrumbs.module
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @file
+ * Contains independentpaneltruthrecoveryni_breadcrumbs.module.
+ */

--- a/project/sites/independentpaneltruthrecoveryni/modules/independentpaneltruthrecoveryni_breadcrumbs/independentpaneltruthrecoveryni_breadcrumbs.services.yml
+++ b/project/sites/independentpaneltruthrecoveryni/modules/independentpaneltruthrecoveryni_breadcrumbs/independentpaneltruthrecoveryni_breadcrumbs.services.yml
@@ -1,0 +1,7 @@
+services:
+  independentpaneltruthrecoveryni_breadcrumbs.breadcrumb.board:
+    class: Drupal\independentpaneltruthrecoveryni_breadcrumbs\BoardBreadcrumb
+    arguments: ['@entity_type.manager', '@title_resolver', '@request_stack']
+    tags:
+      - { name: breadcrumb_builder, priority: 105 }
+

--- a/project/sites/independentpaneltruthrecoveryni/modules/independentpaneltruthrecoveryni_breadcrumbs/src/BoardBreadcrumb.php
+++ b/project/sites/independentpaneltruthrecoveryni/modules/independentpaneltruthrecoveryni_breadcrumbs/src/BoardBreadcrumb.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\independentpaneltruthrecoveryni_breadcrumbs;
+
+/**
+ * @file
+ * Generates the breadcrumb trail for content including:
+ * - Board member
+ *
+ * In the format:
+ * > Home
+ * > Our Structure
+ * > current-page-title
+ *
+ * > <front>
+ * > /our-structure
+ * > /current-page-title
+ */
+use Drupal\Core\Breadcrumb\Breadcrumb;
+use Drupal\Core\Breadcrumb\BreadcrumbBuilderInterface;
+use Drupal\Core\Controller\TitleResolverInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Link;
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * {@inheritdoc}
+ */
+class BoardBreadcrumb implements BreadcrumbBuilderInterface {
+
+  /**
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Node object, or null if on a non-node page.
+   *
+   * @var \Drupal\node\Entity\Node
+   */
+  protected $node;
+
+  /**
+   * The title resolver.
+   *
+   * @var \Drupal\Core\Controller\TitleResolverInterface
+   */
+  protected $titleResolver;
+
+  /**
+   * Symfony\Component\HttpFoundation\RequestStack definition.
+   *
+   * @var Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $request;
+
+  /**
+   * Class constructor.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, TitleResolverInterface $title_resolver, RequestStack $request) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->titleResolver = $title_resolver;
+    $this->request = $request;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('title_resolver'),
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function applies(RouteMatchInterface $route_match) {
+    $match = FALSE;
+    $route_name = $route_match->getRouteName();
+    if ($route_name == 'entity.node.canonical') {
+      $this->node = $route_match->getParameter('node');
+      if ($this->node instanceof NodeInterface == FALSE) {
+        $this->node = $this->entityTypeManager->getStorage('node')->load($this->node);
+      }
+      if (!empty($this->node)) {
+        if ($this->node->bundle() == 'board_member') {
+          $match = TRUE;
+        }
+      }
+    }
+    return $match;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build(RouteMatchInterface $route_match) {
+    $breadcrumb = new Breadcrumb();
+    $title_resolver = $this->titleResolver->getTitle($this->request->getCurrentRequest(), $route_match->getRouteObject());
+    if ($this->node) {
+      $links[] = Link::createFromRoute(t('Home'), '<front>');
+      $links[] = Link::fromTextandUrl(t('Independent Panel Members'), Url::fromUri('internal:/members-independent-panel'));
+      $links[] = Link::createFromRoute($title_resolver, '<none>');
+      $breadcrumb->setLinks($links);
+    }
+    $breadcrumb->addCacheContexts(['url.path']);
+    return $breadcrumb;
+  }
+
+}

--- a/project/sites/independentpaneltruthrecoveryni/themes/independentpaneltruthrecoveryni_theme/independentpaneltruthrecoveryni_theme.info.yml
+++ b/project/sites/independentpaneltruthrecoveryni/themes/independentpaneltruthrecoveryni_theme/independentpaneltruthrecoveryni_theme.info.yml
@@ -6,7 +6,8 @@ core_version_requirement: ^8.8 || ^9 || ^10
 
 libraries:
   - independentpaneltruthrecoveryni_theme/site-styling
-
+  - nicsdru_unity_theme/board_member
+  -
 libraries-override:
   nicsdru_unity_theme/unity-global-styling:
     css:


### PR DESCRIPTION
- Board member view & entity queue configured
- Custom breadcrumb module for board member pages
- Exporting fastly settings
- Tweak to Board member content type for display
- Fix on publication view when no results showing