### PR TITLE
Deleting fastly settings from config - Truth Recovery

### DIFF
--- a/project/config/independentpaneltruthrecoveryni/config/core.entity_view_display.node.feature.default.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/core.entity_view_display.node.feature.default.yml
@@ -36,6 +36,7 @@ content:
     weight: 0
     region: content
 hidden:
+  content_moderation_control: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/project/config/independentpaneltruthrecoveryni/config/core.entity_view_display.node.feature.diff.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/core.entity_view_display.node.feature.diff.yml
@@ -21,14 +21,15 @@ content:
       view_mode: landscape_float
       link: false
     third_party_settings: {  }
-    weight: 1
+    weight: 0
     region: content
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 1
     region: content
 hidden:
+  content_moderation_control: true
   field_link: true
   langcode: true
   search_api_excerpt: true

--- a/project/config/independentpaneltruthrecoveryni/config/core.entity_view_display.node.feature.teaser.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/core.entity_view_display.node.feature.teaser.yml
@@ -26,9 +26,10 @@ content:
   links:
     settings: {  }
     third_party_settings: {  }
-    weight: 100
+    weight: 1
     region: content
 hidden:
+  content_moderation_control: true
   field_link: true
   langcode: true
   search_api_excerpt: true

--- a/project/config/independentpaneltruthrecoveryni/config/fastly.settings.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/fastly.settings.yml
@@ -1,1 +1,0 @@
-site_id: yjc2tgu6

--- a/project/config/independentpaneltruthrecoveryni/config/search_api.index.default_content.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/search_api.index.default_content.yml
@@ -134,6 +134,7 @@ field_settings:
 
 
 
+
       fields:
         - 'entity:node/body'
         - 'entity:node/title'


### PR DESCRIPTION
-Deleting fastly settings from main config to fix edge failure
-Removing moderation control from feature displays