### PR TITLE
Permission tweak & webform confirmation settings changed - Truth Recovery

### DIFF
--- a/project/config/independentpaneltruthrecoveryni/config/user.role.supervisor_user.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/user.role.supervisor_user.yml
@@ -14,6 +14,7 @@ dependencies:
     - node.type.feature
     - node.type.news
     - node.type.publication
+    - node.type.webform
     - workflows.workflow.nics_editorial_workflow
   module:
     - content_moderation
@@ -101,6 +102,7 @@ permissions:
   - 'edit any news content'
   - 'edit any publication content'
   - 'edit any remote_video media'
+  - 'edit any webform content'
   - 'edit basic meta tags'
   - 'edit own audio media'
   - 'edit own basic_page content'
@@ -124,6 +126,7 @@ permissions:
   - 'revert feature revisions'
   - 'revert news revisions'
   - 'revert publication revisions'
+  - 'revert webform revisions'
   - 'update board_members_queue entityqueue'
   - 'update homepage_block_bundle entityqueue'
   - 'use moderation sidebar'
@@ -153,3 +156,4 @@ permissions:
   - 'view scheduled transitions node news'
   - 'view scheduled transitions node publication'
   - 'view the administration theme'
+  - 'view webform revisions'

--- a/project/config/independentpaneltruthrecoveryni/config/webform.webform.contact_the_panel.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/webform.webform.contact_the_panel.yml
@@ -138,7 +138,7 @@ settings:
   confirmation_message: 'Thank you for contacting us.'
   confirmation_attributes: {  }
   confirmation_back: true
-  confirmation_back_label: 'Back to Contact the Panel'
+  confirmation_back_label: 'Back to Contact the Panel page'
   confirmation_back_attributes: {  }
   confirmation_exclude_query: false
   confirmation_exclude_token: false

--- a/project/config/independentpaneltruthrecoveryni/config/webform.webform.contact_the_panel.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/webform.webform.contact_the_panel.yml
@@ -132,13 +132,13 @@ settings:
   draft_loaded_message: ''
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
-  confirmation_type: inline
+  confirmation_type: page
   confirmation_url: ''
   confirmation_title: Success
   confirmation_message: 'Thank you for contacting us.'
   confirmation_attributes: {  }
-  confirmation_back: false
-  confirmation_back_label: ''
+  confirmation_back: true
+  confirmation_back_label: 'Back to Contact the Panel'
   confirmation_back_attributes: {  }
   confirmation_exclude_query: false
   confirmation_exclude_token: false

--- a/project/config/independentpaneltruthrecoveryni/config/webform.webform.giving_your_testimony.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/webform.webform.giving_your_testimony.yml
@@ -132,13 +132,13 @@ settings:
   draft_loaded_message: ''
   draft_pending_single_message: ''
   draft_pending_multiple_message: ''
-  confirmation_type: inline
+  confirmation_type: page
   confirmation_url: ''
   confirmation_title: Success
   confirmation_message: 'Thank you for sharing your experience with us.'
   confirmation_attributes: {  }
-  confirmation_back: false
-  confirmation_back_label: ''
+  confirmation_back: true
+  confirmation_back_label: 'Back to Testimony page'
   confirmation_back_attributes: {  }
   confirmation_exclude_query: false
   confirmation_exclude_token: false


### PR DESCRIPTION
- Updating permissions to allow supervisors to edit webform content
- Confirmation settings changed to a page instead of a message