### PR TITLE
Enabling duration settings to fix hidden end date field - Horizon

### DIFF
--- a/project/config/horizoneuropeni/config/core.entity_form_display.node.event.default.yml
+++ b/project/config/horizoneuropeni/config/core.entity_form_display.node.event.default.yml
@@ -21,7 +21,6 @@ third_party_settings:
     group_event_date_time:
       children:
         - field_event_date
-        - field_start_time
       label: 'Event date(s) and time'
       region: content
       parent_name: ''
@@ -87,6 +86,7 @@ content:
       hide_date: false
       allday: true
       remove_seconds: false
+      duration_overlay: false
     third_party_settings: {  }
   field_location:
     type: string_textfield

--- a/project/config/horizoneuropeni/config/field.field.node.event.field_event_date.yml
+++ b/project/config/horizoneuropeni/config/field.field.node.event.field_event_date.yml
@@ -18,7 +18,7 @@ translatable: false
 default_value:
   -
     default_duration: 0
-    default_duration_increments: custom
+    default_duration_increments: "custom\r\n30|30 minutes\r\n60|1 hour\r\n120|2 hours\r\n180|3 hours\r\n360|6 hours\r\n"
     default_date_type: now
     default_date: ''
     min: ''


### PR DESCRIPTION
- Fix for Hidden end date on Event content form - Horizon Europe NI