### PR TITLE
Fixing Menu Link bug - Unity 3

### DIFF
--- a/project/config/boundarycommission/config/node.type.basic_page.yml
+++ b/project/config/boundarycommission/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/boundarycommission/config/node.type.news.yml
+++ b/project/config/boundarycommission/config/node.type.news.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/horizoneuropeni/config/node.type.basic_page.yml
+++ b/project/config/horizoneuropeni/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/horizoneuropeni/config/node.type.board_member.yml
+++ b/project/config/horizoneuropeni/config/node.type.board_member.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/horizoneuropeni/config/node.type.event.yml
+++ b/project/config/horizoneuropeni/config/node.type.event.yml
@@ -6,9 +6,8 @@ dependencies:
     - menu_ui
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
 name: Event
 type: event
 description: null

--- a/project/config/horizoneuropeni/config/node.type.featured_link.yml
+++ b/project/config/horizoneuropeni/config/node.type.featured_link.yml
@@ -6,9 +6,8 @@ dependencies:
     - menu_ui
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
 name: 'Featured Link'
 type: featured_link
 description: null

--- a/project/config/horizoneuropeni/config/node.type.news.yml
+++ b/project/config/horizoneuropeni/config/node.type.news.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/independentpaneltruthrecoveryni/config/node.type.basic_page.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/independentpaneltruthrecoveryni/config/node.type.board_member.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/node.type.board_member.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/independentpaneltruthrecoveryni/config/node.type.feature.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/node.type.feature.yml
@@ -6,9 +6,8 @@ dependencies:
     - menu_ui
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
 name: Feature
 type: feature
 description: ''

--- a/project/config/independentpaneltruthrecoveryni/config/node.type.institutions.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/node.type.institutions.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/independentpaneltruthrecoveryni/config/node.type.landing_page.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/node.type.landing_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/independentpaneltruthrecoveryni/config/node.type.news.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/node.type.news.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/independentpaneltruthrecoveryni/config/node.type.webform.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/node.type.webform.yml
@@ -10,9 +10,8 @@ dependencies:
       - webform_node
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/infolibrarynics/config/node.type.basic_page.yml
+++ b/project/config/infolibrarynics/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/infolibrarynics/config/node.type.faq.yml
+++ b/project/config/infolibrarynics/config/node.type.faq.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/interchangeni/config/node.type.basic_page.yml
+++ b/project/config/interchangeni/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/interchangeni/config/node.type.feature.yml
+++ b/project/config/interchangeni/config/node.type.feature.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/interchangeni/config/node.type.manager.yml
+++ b/project/config/interchangeni/config/node.type.manager.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/interchangeni/config/node.type.opportunity.yml
+++ b/project/config/interchangeni/config/node.type.opportunity.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/judiciaryni/config/node.type.basic_page.yml
+++ b/project/config/judiciaryni/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/judiciaryni/config/node.type.feature.yml
+++ b/project/config/judiciaryni/config/node.type.feature.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/lgbcni/config/node.type.basic_page.yml
+++ b/project/config/lgbcni/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/lgbcni/config/node.type.faq.yml
+++ b/project/config/lgbcni/config/node.type.faq.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/lgbcni/config/node.type.feature.yml
+++ b/project/config/lgbcni/config/node.type.feature.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/lgbcni/config/node.type.news.yml
+++ b/project/config/lgbcni/config/node.type.news.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/liofa/config/node.type.basic_page.yml
+++ b/project/config/liofa/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/liofa/config/node.type.bulk_pledges.yml
+++ b/project/config/liofa/config/node.type.bulk_pledges.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/liofa/config/node.type.news.yml
+++ b/project/config/liofa/config/node.type.news.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/nibureau/config/node.type.basic_page.yml
+++ b/project/config/nibureau/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/nibureau/config/node.type.board_member.yml
+++ b/project/config/nibureau/config/node.type.board_member.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/nibureau/config/node.type.feature.yml
+++ b/project/config/nibureau/config/node.type.feature.yml
@@ -6,9 +6,8 @@ dependencies:
     - menu_ui
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
 name: Feature
 type: feature
 description: ''

--- a/project/config/nicscommissioners/config/node.type.basic_page.yml
+++ b/project/config/nicscommissioners/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/nicscommissioners/config/node.type.board_member.yml
+++ b/project/config/nicscommissioners/config/node.type.board_member.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/nicscommissioners/config/node.type.featured_content.yml
+++ b/project/config/nicscommissioners/config/node.type.featured_content.yml
@@ -6,9 +6,8 @@ dependencies:
     - menu_ui
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
 name: 'Featured Content'
 type: featured_content
 description: ''

--- a/project/config/pacni/config/node.type.basic_page.yml
+++ b/project/config/pacni/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/pacni/config/node.type.feature.yml
+++ b/project/config/pacni/config/node.type.feature.yml
@@ -6,9 +6,8 @@ dependencies:
     - menu_ui
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
 name: Feature
 type: feature
 description: 'Use this content type to generate items of featured content.'

--- a/project/config/pacni/config/node.type.news.yml
+++ b/project/config/pacni/config/node.type.news.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/parolecomni/config/node.type.basic_page.yml
+++ b/project/config/parolecomni/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/pressclippingsnics/config/node.type.press_clippings.yml
+++ b/project/config/pressclippingsnics/config/node.type.press_clippings.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/semcommittee/config/node.type.basic_page.yml
+++ b/project/config/semcommittee/config/node.type.basic_page.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 1
     toc_title: Contents

--- a/project/config/semcommittee/config/node.type.board_member.yml
+++ b/project/config/semcommittee/config/node.type.board_member.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'

--- a/project/config/semcommittee/config/node.type.feature.yml
+++ b/project/config/semcommittee/config/node.type.feature.yml
@@ -6,9 +6,8 @@ dependencies:
     - menu_ui
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
 name: Feature
 type: feature
 description: null

--- a/project/config/semcommittee/config/node.type.news.yml
+++ b/project/config/semcommittee/config/node.type.news.yml
@@ -7,9 +7,8 @@ dependencies:
     - origins_toc
 third_party_settings:
   menu_ui:
-    available_menus:
-      - main
-    parent: 'main:'
+    available_menus: {  }
+    parent: ''
   origins_toc:
     toc_enable: 0
     toc_title: 'Table of contents'


### PR DESCRIPTION
- Disabling the Menu Link option from node edit screen on all Content types