### PR TITLE
D8UN-3428

### DIFF
--- a/project/config/boundarycommission/config/core.extension.yml
+++ b/project/config/boundarycommission/config/core.extension.yml
@@ -99,7 +99,7 @@ module:
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/horizoneuropeni/config/core.extension.yml
+++ b/project/config/horizoneuropeni/config/core.extension.yml
@@ -93,7 +93,7 @@ module:
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/independentpaneltruthrecoveryni/config/core.extension.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/core.extension.yml
@@ -101,7 +101,7 @@ module:
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/infolibrarynics/config/core.extension.yml
+++ b/project/config/infolibrarynics/config/core.extension.yml
@@ -95,7 +95,7 @@ module:
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/interchangeni/config/core.extension.yml
+++ b/project/config/interchangeni/config/core.extension.yml
@@ -97,7 +97,7 @@ module:
   origins_metatag: 0
   origins_qa: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/judiciaryni/config/core.extension.yml
+++ b/project/config/judiciaryni/config/core.extension.yml
@@ -94,12 +94,12 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_unique_title: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/judiciaryni/config/origins_forms.settings.yml
+++ b/project/config/judiciaryni/config/origins_forms.settings.yml
@@ -1,1 +1,8 @@
+excluded_bundles:
+  basic_page: '0'
+  feature: '0'
+  judicial_decision: '0'
+  judicial_member: '0'
+  publication: '0'
+  webform: '0'
 exclude_ids_list: "7964\r\n6447\r\n8347\r\n8436\r\n8334\r\n7330\r\n8263\r\n5619\r\n7227\r\n7518\r\n6448\r\n6288\r\n6037\r\n5641\r\n5623\r\n5622\r\n3336\r\n1054\r\n1052\r\n6956\r\n7177\r\n6505\r\n5643"

--- a/project/config/lgbcni/config/core.extension.yml
+++ b/project/config/lgbcni/config/core.extension.yml
@@ -95,7 +95,7 @@ module:
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/liofa/config/core.extension.yml
+++ b/project/config/liofa/config/core.extension.yml
@@ -100,7 +100,7 @@ module:
   origins_metatag: 0
   origins_qa: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/nibureau/config/core.extension.yml
+++ b/project/config/nibureau/config/core.extension.yml
@@ -97,7 +97,7 @@ module:
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/nicscommissioners/config/core.extension.yml
+++ b/project/config/nicscommissioners/config/core.extension.yml
@@ -96,7 +96,7 @@ module:
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/pacni/config/core.extension.yml
+++ b/project/config/pacni/config/core.extension.yml
@@ -99,7 +99,7 @@ module:
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/parolecomni/config/core.extension.yml
+++ b/project/config/parolecomni/config/core.extension.yml
@@ -98,7 +98,7 @@ module:
   origins_metatag: 0
   origins_qa: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/pressclippingsnics/config/core.extension.yml
+++ b/project/config/pressclippingsnics/config/core.extension.yml
@@ -90,7 +90,7 @@ module:
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/project/config/semcommittee/config/core.extension.yml
+++ b/project/config/semcommittee/config/core.extension.yml
@@ -97,7 +97,7 @@ module:
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_unique_title: 0
+  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0


### PR DESCRIPTION
- Uninstalling the Origins Unique Title module and Installing the Origins:Forms module as it has the functionality instead.
- Judiciary site had some excluded nodes using the Unique Title module, they have been moved to the Forms module config