### PR TITLE
D8UN-3543 (D8UN-3549 - Unity 3)

### DIFF
--- a/project/config/boundarycommission/config/core.extension.yml
+++ b/project/config/boundarycommission/config/core.extension.yml
@@ -94,12 +94,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -130,7 +131,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_map_block: 0
   unity_search_pages: 0
   user: 0

--- a/project/config/horizoneuropeni/config/core.extension.yml
+++ b/project/config/horizoneuropeni/config/core.extension.yml
@@ -88,12 +88,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -122,7 +123,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   update: 0
   user: 0

--- a/project/config/independentpaneltruthrecoveryni/config/core.extension.yml
+++ b/project/config/independentpaneltruthrecoveryni/config/core.extension.yml
@@ -98,6 +98,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -135,7 +136,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_landing_pages: 0
   unity_search_pages: 0
   update: 0

--- a/project/config/infolibrarynics/config/core.extension.yml
+++ b/project/config/infolibrarynics/config/core.extension.yml
@@ -90,12 +90,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -121,7 +122,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   update: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/interchangeni/config/core.extension.yml
+++ b/project/config/interchangeni/config/core.extension.yml
@@ -95,6 +95,7 @@ module:
   options: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -131,7 +132,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_map_block: 0
   unity_search_pages: 0
   update: 0

--- a/project/config/judiciaryni/config/core.extension.yml
+++ b/project/config/judiciaryni/config/core.extension.yml
@@ -96,6 +96,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -134,7 +135,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/lgbcni/config/core.extension.yml
+++ b/project/config/lgbcni/config/core.extension.yml
@@ -92,6 +92,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -130,7 +131,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   update: 0
   user: 0

--- a/project/config/liofa/config/core.extension.yml
+++ b/project/config/liofa/config/core.extension.yml
@@ -98,6 +98,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -135,7 +136,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   update: 0
   user: 0

--- a/project/config/nibureau/config/core.extension.yml
+++ b/project/config/nibureau/config/core.extension.yml
@@ -94,6 +94,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -129,7 +130,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   update: 0
   user: 0

--- a/project/config/nicscommissioners/config/core.extension.yml
+++ b/project/config/nicscommissioners/config/core.extension.yml
@@ -91,12 +91,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -127,7 +128,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   update: 0
   user: 0

--- a/project/config/pacni/config/core.extension.yml
+++ b/project/config/pacni/config/core.extension.yml
@@ -96,6 +96,7 @@ module:
   options: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -134,7 +135,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_map_embed: 0
   unity_search_pages: 0
   user: 0

--- a/project/config/parolecomni/config/core.extension.yml
+++ b/project/config/parolecomni/config/core.extension.yml
@@ -94,11 +94,12 @@ module:
   noreferrer: 0
   options: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -129,7 +130,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_map_block: 0
   unity_search_pages: 0
   update: 0

--- a/project/config/pressclippingsnics/config/core.extension.yml
+++ b/project/config/pressclippingsnics/config/core.extension.yml
@@ -85,12 +85,13 @@ module:
   options: 0
   origins_ckeditor_enhancements: 0
   origins_common: 0
+  origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
   origins_search_views_routing: 0
   origins_toc: 0
-  origins_forms: 0
   page_cache: 0
   path: 0
   path_alias: 0
@@ -122,7 +123,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   user: 0
   views_custom_cache_tag: 0

--- a/project/config/semcommittee/config/core.extension.yml
+++ b/project/config/semcommittee/config/core.extension.yml
@@ -93,6 +93,7 @@ module:
   origins_ckeditor_enhancements: 0
   origins_common: 0
   origins_forms: 0
+  origins_internal_link_checker: 0
   origins_media: 0
   origins_metatag: 0
   origins_qa: 0
@@ -132,7 +133,6 @@ module:
   unity_eu_cookie_compliance: 0
   unity_frontpage: 0
   unity_image_styles: 0
-  unity_internal_link_checker: 0
   unity_search_pages: 0
   update: 0
   user: 0


### PR DESCRIPTION
- Unity Internal Link checker module uninstalled on all Unity 3 sites
- Origins Internal Link checker module installed on all Unity 3 sites
- No config existed on any of these sites for the previous module.